### PR TITLE
fix name in quickfuture.qmltypes to make qmllint happy

### DIFF
--- a/src/quickfuture.qmltypes
+++ b/src/quickfuture.qmltypes
@@ -9,7 +9,7 @@ import QtQuick.tooling 1.2
 Module {
     dependencies: ["QtQuick 2.8"]
     Component {
-        name: "QuickFuture::Future"
+        name: "Future"
         prototype: "QObject"
         exports: ["QuickFuture/Future 1.0"]
         isCreatable: false


### PR DESCRIPTION
`::` can not be used in javacript names, so in qml should be used
`Future.` instead of `QuickFuture::Future.`.
But for such code qmllint reports:
Warning: unqualified access at
Future.onFinished
^^^^^^